### PR TITLE
fix (cutData.R): don't overwrite existing "year" columns w/ yearseason

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -34,6 +34,8 @@
 
 - `importUKAQ()` will correctly append site meta data when `meta = TRUE`, `source` is a length greater than 1, and a single site is repeated in more than one source (e.g., `importUKAQ(source = c("waqn", "aurn"), data_type = "daqi", year = 2024L))`)
 
+- `cutData()` will no longer overwrite existing `year` columns if using `"yearseason"`.
+
 # openair 2.18-2
 
 ## New Features

--- a/R/cutData.R
+++ b/R/cutData.R
@@ -330,7 +330,6 @@ cutData <- function(x, type = "default", hemisphere = "northern",
     }
 
     if (type %in% c("seasonyear", "yearseason")) {
-
       # this cuts data to ensure that a season spans two years to keep it together
       # For example, winter 2015 is considered  Dec. 2014 and Jan. Feb, 2015
 
@@ -341,17 +340,18 @@ cutData <- function(x, type = "default", hemisphere = "northern",
       ## calculate year
       x <- mutate(
         x,
-        year = lubridate::year(date),
-        month = lubridate::month(date)
+        openair__year = lubridate::year(date),
+        openair__month = lubridate::month(date)
       )
 
       ## ids where month = 12, make December part of following year's season
-      ids <- which(x$month == 12)
-      x$year[ids] <- x$year[ids] + 1
+      ids <- which(x$openair__month == 12)
+      x$openair__year[ids] <- x$openair__year[ids] + 1
 
-      labels <- paste(x$season, "-", x$year)
+      labels <- paste(x$season, "-", x$openair__year)
       x[[type]] <- labels
       x[[type]] <- ordered(x[[type]], levels = unique(x[[type]]))
+      x$openair__year <- x$openair__month <- NULL
     }
 
     if (type == "weekend") {


### PR DESCRIPTION
This PR fixes #404. cc @mooibroekd.

In short, when using `cutData()` w/ "yearseason" openair would overwrite existing `year` columns.

I've renamed the interim columns to be `openair__year` and `openair__month`, which are then deleted before the data is returned.

Using interim columns feels dodgy; a safer bet would be working on the vectors themselves I think. But this fix should work for the time being.

I note the function does leave a floating `season` column in the output which the user has not requested, but I don't want to remove it too in case the user already has a `season` column.

There may be broader improvements needed to how `cutData()` works in future - it can be very destructive to the user's own data if they're not careful.

``` r
devtools::load_all()
#> ℹ Loading openair

# create some date data for illustration
test <- data.frame(date = seq.Date(
  lubridate::date("2022-01-01"),
  lubridate::date("2022-12-31"),
  by = 1
))

# cut the data into years
test <- cutData(test, type = "year")

# check if we have any dates that are associated with 2023
test |>
  dplyr::filter(year == 2023)
#> [1] date year
#> <0 rows> (or 0-length row.names)

# now cut the data to yearseason
test <- cutData(test, type = "yearseason")

# perform the test again:
test |> filter(year == 2023)
#> [1] date       year       season     yearseason
#> <0 rows> (or 0-length row.names)
```

<sup>Created on 2025-01-22 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
