### PR TITLE
Add an arigument to allow for overwriting the annotation size for the date

### DIFF
--- a/R/calendarPlot.R
+++ b/R/calendarPlot.R
@@ -75,6 +75,7 @@
 #' @param cex.lim For the annotation of concentration labels on each day. The
 #'   first sets the size of the text below `lim` and the second sets the size of
 #'   the text above `lim`.
+#' @param cex.date The base size of the annotation text for the date.
 #' @param digits The number of digits used to display concentration values when
 #'   `annotate = "value"`.
 #' @param data.thresh Data capture threshold passed to [timeAverage()]. For
@@ -169,6 +170,7 @@ calendarPlot <-
            col.arrow = "black",
            font.lim = c(1, 2),
            cex.lim = c(0.6, 1),
+           cex.date = 0.6,
            digits = 0,
            data.thresh = 0,
            labels = NA,
@@ -591,7 +593,7 @@ calendarPlot <-
             x[subscripts],
             y[subscripts],
             labels = mydata$date.mat[subscripts],
-            cex = 0.6,
+            cex = cex.date,
             col = as.character(mydata$dateColour[subscripts])
           )
         }
@@ -605,7 +607,7 @@ calendarPlot <-
             x[subscripts],
             y[subscripts],
             labels = mydata$date.mat[subscripts],
-            cex = 0.6,
+            cex = cex.date,
             col = date.col
           )
 

--- a/man/calendarPlot.Rd
+++ b/man/calendarPlot.Rd
@@ -19,6 +19,7 @@ calendarPlot(
   col.arrow = "black",
   font.lim = c(1, 2),
   cex.lim = c(0.6, 1),
+  cex.date = 0.6,
   digits = 0,
   data.thresh = 0,
   labels = NA,
@@ -92,6 +93,8 @@ bold text.}
 \item{cex.lim}{For the annotation of concentration labels on each day. The
 first sets the size of the text below \code{lim} and the second sets the size of
 the text above \code{lim}.}
+
+\item{cex.date}{The base size of the annotation text for the date.}
 
 \item{digits}{The number of digits used to display concentration values when
 \code{annotate = "value"}.}


### PR DESCRIPTION
This PR adds a way of overwriting the font size for the annotations when `annotate = "date"`. It maintains the existing default size if no argument is passed. I've tested the results using the fork in the package I'm using.

### Context

I'm part of a team that's been building project that's using the `calendarPlot` function. Thanks for your work maintaining this project, it's definitely given us a quick way to get nice calendar plots!

We are having issues with the size of the text for dates in the plot when `annotate = "date"`. I can see there's a way to overwrite it for `annotate = "value"` but not for `"date"`. I tried setting the font size through other means, like `fontsize` or the other `par.x.text = list(cex = x)` options but I couldn't find a method that worked for the annotation text (though those worked for other parts of the plot, like the heading and the weekday letters).

I did find a workaround: changing the dimensions of the output plot to be much higher than intended to get a different font size (but that didn't feel great).

I've tested this in my local environment with this project and it seems to work now!

If there's another better way to do so already inbuilt, I'd be happy to close this PR and use that. Otherwise, happy to hear and take action on feedback.