### PR TITLE
refine `timeAverage()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -70,6 +70,8 @@
 
 - `calcPercentile()` will now correctly pass its arguments (e.g., `date.start`) to `timeAverage()`.
 
+- `timeAverage()` will now more consistently return `NA` values rather than `NaN` or `Inf` when all values are `NA`. This specifically affects the `"mean"` and `"min"` statistics.
+
 # openair 2.18-2
 
 ## New Features

--- a/R/timeAverage.R
+++ b/R/timeAverage.R
@@ -262,10 +262,9 @@ timeAverage <- function(
 
     ## If interval of original time series not specified, calculate it
     ## time diff in seconds of original data
-    timeDiff <- as.numeric(strsplit(
-      find.time.interval(mydata$date),
-      " "
-    )[[1]][1])
+    timeDiff <- as.numeric(strsplit(find.time.interval(mydata$date), " ")[[1]][
+      1
+    ])
 
     ## time diff of new interval
     by2 <- strsplit(avg.time, " ", fixed = TRUE)[[1]]
@@ -280,7 +279,11 @@ timeAverage <- function(
     if (units == "day") int <- 3600 * 24
     if (units == "week") int <- 3600 * 24 * 7
     if (units == "month") int <- 3600 * 24 * 31 ## approx
-    if (units == "quarter" || units == "season") int <- 3600 * 24 * 31 * 3 ## approx
+    if (
+      units == "quarter" ||
+        units == "season"
+    )
+      int <- 3600 * 24 * 31 * 3 ## approx
     if (units == "year") int <- 3600 * 8784 ## approx
 
     seconds <- seconds * int ## interval in seconds
@@ -429,29 +432,25 @@ timeAverage <- function(
 
         avmet <- mydata %>%
           group_by(across(vars)) %>%
-          summarise(
-            across(
-              everything(),
-              ~ if (sum(is.na(.x)) / length(.x) <= 1 - data.thresh) {
-                mean(.x, na.rm = TRUE)
-              } else {
-                NA
-              }
-            )
-          )
+          summarise(across(
+            where(function(x) !is.factor(x) && !is.character(x)),
+            ~ if (sum(is.na(.x)) / length(.x) <= 1 - data.thresh) {
+              mean(.x, na.rm = TRUE)
+            } else {
+              NA
+            }
+          ))
       } else {
         avmet <- mydata %>%
           group_by(across(vars)) %>%
-          summarise(
-            across(
-              everything(),
-              ~ if (sum(is.na(.x)) / length(.x) <= 1 - data.thresh) {
-                FUN(.x)
-              } else {
-                NA
-              }
-            )
-          )
+          summarise(across(
+            where(function(x) !is.factor(x) && !is.character(x)),
+            ~ if (sum(is.na(.x)) / length(.x) <= 1 - data.thresh) {
+              FUN(.x)
+            } else {
+              NA
+            }
+          ))
       }
     } else {
       ## faster if do not need data capture
@@ -471,10 +470,16 @@ timeAverage <- function(
       # This is much faster for some reason
       if (statistic == "mean") {
         avmet <- avmet %>%
-          summarise(across(everything(), ~ mean(.x, na.rm = TRUE)))
+          summarise(across(
+            where(function(x) !is.factor(x) && !is.character(x)),
+            ~ mean(.x, na.rm = TRUE)
+          ))
       } else {
         avmet <- avmet %>%
-          summarise(across(everything(), ~ FUN(.x)))
+          summarise(across(
+            where(function(x) !is.factor(x) && !is.character(x)),
+            ~ FUN(.x)
+          ))
       }
     }
 
@@ -508,12 +513,16 @@ timeAverage <- function(
 
   # cut data into intervals
   mydata <- cutData(mydata, type)
-  
+
   # select date, type, and all non-factor/character columns
   mydata <-
-    dplyr::select(mydata, dplyr::all_of(c("date", type)), dplyr::where(function(x) {
-      !is.character(x) && !is.factor(x)
-    }))
+    dplyr::select(
+      mydata,
+      dplyr::all_of(c("date", type)),
+      dplyr::where(function(x) {
+        !is.character(x) && !is.factor(x)
+      })
+    )
 
   # calculate stats split by type
   if (progress) {
@@ -533,7 +542,7 @@ timeAverage <- function(
     mydata <- subset(mydata, select = -default)
   }
 
-  # return 
+  # return
   return(mydata)
 }
 
@@ -569,10 +578,7 @@ validate_timeaverage_inputs <- function(data.thresh, percentile, statistic) {
     )
   statistic <- rlang::arg_match(statistic, valid_stats)
 
-  return(list(
-    data.thresh = data.thresh,
-    percentile = percentile
-  ))
+  return(list(data.thresh = data.thresh, percentile = percentile))
 }
 
 #' Get an appropriate function for the statistic

--- a/R/timeAverage.R
+++ b/R/timeAverage.R
@@ -384,22 +384,19 @@ timeAverage <- function(
     if ("wd" %in% names(mydata) && statistic != "data.cap") {
       if (is.numeric(mydata$wd)) {
         ## mean wd
-        avmet <- dplyr::mutate(
-          avmet,
-          wd = as.vector(atan2(.data$Uu, .data$Vv) * 360 / 2 / pi)
-        )
-
-        ## correct for negative wind directions
-        ids <- which(avmet$wd < 0) ## ids where wd < 0
-        avmet$wd[ids] <- avmet$wd[ids] + 360
-
+        avmet <-
+          avmet %>%
+          dplyr::mutate(
+            wd = as.vector(atan2(.data$Uu, .data$Vv) * 360 / 2 / pi),
+            # correct negative wind directions
+            wd = dplyr::if_else(.data$wd < 0, .data$wd + 360, .data$wd)
+          )
+        
         ## vector average ws
-        if ("ws" %in% names(mydata)) {
-          if (vector.ws) {
-            avmet <- dplyr::mutate(avmet, ws = (.data$Uu^2 + .data$Vv^2)^0.5)
-          }
+        if ("ws" %in% names(mydata) && vector.ws) {
+          avmet <- dplyr::mutate(avmet, ws = (.data$Uu^2 + .data$Vv^2)^0.5)
         }
-
+        
         avmet <- dplyr::select(avmet, -"Uu", -"Vv")
       }
     }

--- a/R/timeAverage.R
+++ b/R/timeAverage.R
@@ -506,7 +506,7 @@ timeAverage <- function(
     avmet
   }
 
-  ## cut data into intervals
+  # cut data into intervals
   mydata <- cutData(mydata, type)
 
   ## ids of numeric columns, type and date
@@ -515,19 +515,6 @@ timeAverage <- function(
     which(sapply(mydata, function(x) !is.factor(x) && !is.character(x)))
   )
   mydata <- mydata[, unique(ids)]
-
-  ## some LAQN data seem to have the odd missing site name
-  if ("site" %in% names(mydata)) {
-    ## split by site
-
-    ## remove any NA sites
-    if (anyNA(mydata$site)) {
-      id <- which(is.na(mydata$site))
-      mydata <- mydata[-id, ]
-    }
-
-    mydata$site <- factor(mydata$site) ## removes empty factors
-  }
 
   ## calculate stats split by type
   if (progress) progress <- "Calculating Time Averages"

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -86,38 +86,6 @@ find.time.interval <- function(dates) {
   seconds
 }
 
-
-date.pad2 <- function(mydata, type = NULL, interval = "month") {
-  # assume by the time we get here the data have been split into types
-  # This means we just need to pad out the missing types based on first
-  # line.
-
-  start.date <- min(mydata$date, na.rm = TRUE)
-  end.date <- max(mydata$date, na.rm = TRUE)
-
-  # interval is in seconds, so convert to days if Date class and not POSIXct
-  if (class(mydata$date)[1] == "Date") {
-    interval <- paste(
-      as.numeric(strsplit(interval, " ")[[1]][1]) / 3600 / 24,
-      "days"
-    )
-  }
-
-  all.dates <- data.frame(date = seq(start.date, end.date, by = interval))
-  mydata <- mydata %>% full_join(all.dates, by = "date")
-
-  # add in missing types if gaps are made
-  if (!is.null(type)) {
-    mydata[type] <- mydata[1, type]
-  }
-
-  # make sure order is correct
-  mydata <- arrange(mydata, date)
-
-  return(mydata)
-}
-
-
 ## #################################################################
 # Function to pad out missing time data
 # assumes data have already been split by type, so just take first


### PR DESCRIPTION
This PR refactors `timeAverage()`.

It is an attempt to modernise `timeAverage()` to use up-to-date dplyr/tidyr/purrr/etc., as well as modularise it by pulling out various discrete parts of the function body into helpers (e.g., dealing with `avg.time = "season"`. Some internal variables have also been renamed for clarity. I believe this makes `timeAverage()` clearer to read and develop.

It also comes with one fix - stat = "mean" and stat = "min" will now return `NA`s rather than `NaN` and `-Inf`. This makes all statistic types work consistently.