### PR TITLE
Add missing `ws` & `wd` args to directional analysis functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -56,6 +56,8 @@
 
 - `trendLevel()` will now automatically generate appropriate `labels` if `breaks` are provided. The `labels` argument can still be used to provide custom labels per break.
 
+- `polarDiff()`, `percentileRose()`, `polarFreq()` and `polarAnnulus()` all gain the `ws` and/or `wd` arguments (as appropriate), in line with `polarPlot()` and `windRose()`.
+
 ## Bug fixes
 
 - Fixed repeated day number in `calendarPlot` when `statistic = max`.

--- a/R/percentileRose.R
+++ b/R/percentileRose.R
@@ -28,6 +28,7 @@
 #' the user has fine control over both the range, interval and colour.
 #'
 #' @inheritParams polarPlot
+#' @inheritParams windRose
 #' @param mydata A data frame minimally containing `wd` and a numeric field
 #'   to plot --- `pollutant`.
 #' @param pollutant Mandatory. A pollutant name corresponding to a variable in a
@@ -88,6 +89,7 @@
 percentileRose <- function(
   mydata,
   pollutant = "nox",
+  ws = "ws",
   wd = "wd",
   type = "default",
   percentile = c(25, 50, 75, 90, 95),
@@ -124,16 +126,19 @@ percentileRose <- function(
 
   if (tolower(method) == "cpf") {
     mean <- FALSE
-    if (length(percentile) > 1)
+    if (length(percentile) > 1) {
       stop("Only one percentile should be supplied when method = 'CPF'.")
+    }
   }
 
   vars <- c(wd, pollutant)
-  if (any(type %in% dateTypes)) vars <- c(vars, "date")
+  if (any(type %in% dateTypes)) {
+    vars <- c(vars, "date")
+  }
 
   # check to see if ws is in the data and is calm (need to remove as no wd)
-  if ("ws" %in% names(mydata)) {
-    id <- which(mydata$ws == 0 & mydata[[wd]] == 0)
+  if (ws %in% names(mydata)) {
+    id <- which(mydata[[ws]] == 0 & mydata[[wd]] == 0)
     if (length(id) > 0) {
       mydata <- mydata[-id, ]
     }
@@ -160,7 +165,9 @@ percentileRose <- function(
   }
 
   ## need lowest value if shading
-  if (fill) percentile <- unique(c(0, percentile))
+  if (fill) {
+    percentile <- unique(c(0, percentile))
+  }
 
   # number of pollutants
   npol <- length(pollutant)
@@ -365,7 +372,11 @@ percentileRose <- function(
     Mean <- purrr::map(999, mod.percentiles) %>%
       purrr::list_rbind()
 
-    if (stat == "percentile") results <- results else results <- Mean
+    if (stat == "percentile") {
+      results <- results
+    } else {
+      results <- Mean
+    }
     results
   }
 
@@ -464,7 +475,9 @@ percentileRose <- function(
 
   legend <- makeOpenKeyLegend(key, legend, "percentileRose")
 
-  if (mean.only || tolower(method) == "cpf") legend <- NULL
+  if (mean.only || tolower(method) == "cpf") {
+    legend <- NULL
+  }
 
   temp <- paste(type, collapse = "+")
   myform <- formula(paste("y ~ x | ", temp, sep = ""))
@@ -481,8 +494,9 @@ percentileRose <- function(
 
   ## nice intervals for pollutant concentrations
   tmp <- (results.grid$x^2 + results.grid$y^2)^0.5
-  if (is.null(intervals))
+  if (is.null(intervals)) {
     intervals <- pretty(c(min(tmp, na.rm = TRUE), max(tmp, na.rm = TRUE)))
+  }
 
   labs <- intervals ## the labels
 
@@ -502,7 +516,9 @@ percentileRose <- function(
   }
 
   ## re-label if CPF plot
-  if (tolower(method) == "cpf") pollutant <- "probability"
+  if (tolower(method) == "cpf") {
+    pollutant <- "probability"
+  }
 
   xyplot.args <- list(
     x = myform,

--- a/R/polarDiff.R
+++ b/R/polarDiff.R
@@ -36,8 +36,9 @@ polarDiff <- function(
   before,
   after,
   pollutant = "nox",
-  type = "default",
   x = "ws",
+  wd = "wd",
+  type = "default",
   limits = NULL,
   auto.text = TRUE,
   plot = TRUE,
@@ -52,9 +53,9 @@ polarDiff <- function(
 
   # variables needed, check for York regression where x and y error needed
   if (all(c("x_error", "y_error") %in% names(Args))) {
-    vars <- c(x, "wd", pollutant, Args$x_error, Args$y_error)
+    vars <- c(x, wd, pollutant, Args$x_error, Args$y_error)
   } else {
-    vars <- c(x, "wd", pollutant)
+    vars <- c(x, wd, pollutant)
   }
 
   # check variables exists
@@ -89,6 +90,7 @@ polarDiff <- function(
           theData,
           pollutant = pollutant,
           x = x,
+          wd = wd,
           type = "period",
           plot = FALSE,
           ...
@@ -108,8 +110,8 @@ polarDiff <- function(
           dplyr::mutate(
             {{ pollutant }} := after - before,
             {{ x }} := (u^2 + v^2)^0.5,
-            wd = 180 * atan2(u, v) / pi,
-            wd = ifelse(wd < 0, wd + 360, wd)
+            {{ wd }} := 180 * atan2(u, v) / pi,
+            {{ wd }} := ifelse(.data[[wd]] < 0, .data[[wd]] + 360, .data[[wd]])
           )
 
         polar_data[[type]] <- theData[[type]][1]
@@ -165,6 +167,7 @@ polarDiff <- function(
         polar_data,
         pollutant = pollutant,
         x = x,
+        wd = wd,
         plot = plot,
         cols = Args$cols,
         limits = Args$limits,
@@ -187,6 +190,7 @@ polarDiff <- function(
         polar_data,
         pollutant = pollutant,
         x = x,
+        wd = wd,
         type = "finaltype",
         plot = plot,
         cols = Args$cols,

--- a/R/polarPlot.R
+++ b/R/polarPlot.R
@@ -509,10 +509,14 @@ polarPlot <-
     nam.x <- x
     nam.wd <- wd
 
-    if (length(type) > 2) stop("Maximum number of types is 2.")
+    if (length(type) > 2) {
+      stop("Maximum number of types is 2.")
+    }
 
     ## can't have conditioning here
-    if (uncertainty) type <- "default"
+    if (uncertainty) {
+      type <- "default"
+    }
 
     if (uncertainty & length(pollutant) > 1) {
       stop("Can only have one pollutant when uncertainty = TRUE")
@@ -537,15 +541,23 @@ polarPlot <-
       stop(paste0("statistic '", statistic, "' not recognised."), call. = FALSE)
     }
 
-    if (length(weights) != 3) stop("weights should be of length 3.")
+    if (length(weights) != 3) {
+      stop("weights should be of length 3.")
+    }
 
-    if (key.header == "nwr") key.header <- "NWR"
-    if (key.header == "weighted_mean") key.header <- "weighted\nmean"
+    if (key.header == "nwr") {
+      key.header <- "NWR"
+    }
+    if (key.header == "weighted_mean") {
+      key.header <- "weighted\nmean"
+    }
     if (key.header == "percentile") {
       key.header <- c(paste(percentile, "th", sep = ""), "percentile")
     }
 
-    if ("cpf" %in% key.header) key.header <- c("CPF", "probability")
+    if ("cpf" %in% key.header) {
+      key.header <- c("CPF", "probability")
+    }
 
     ## greyscale handling
     if (length(cols) == 1 && cols == "greyscale") {
@@ -606,7 +618,9 @@ polarPlot <-
       vars <- c(vars, x_error, y_error)
     }
 
-    if (any(type %in% dateTypes)) vars <- c(vars, "date")
+    if (any(type %in% dateTypes)) {
+      vars <- c(vars, "date")
+    }
 
     mydata <- checkPrep(mydata, vars, type, remove.calm = FALSE)
 
@@ -689,9 +703,15 @@ polarPlot <-
       if (toupper(statistic) == "NWR") wd.int <- 2 else wd.int <- 5 ## how to split wd
     }
 
-    if (toupper(statistic) == "NWR") ws_bins <- 40 else ws_bins <- 30
+    if (toupper(statistic) == "NWR") {
+      ws_bins <- 40
+    } else {
+      ws_bins <- 30
+    }
 
-    if (statistic == "nwr") k <- 200 # limit any smoothing
+    if (statistic == "nwr") {
+      k <- 200
+    } # limit any smoothing
 
     ws.seq <- seq(min.ws, max.ws, length = ws_bins)
     wd.seq <- seq(from = wd.int, to = 360, by = wd.int) ## wind directions from wd.int to 360
@@ -908,7 +928,11 @@ polarPlot <-
       # for removing missing data later
       binned.len[ids] <- NA
 
-      if (force.positive) n <- 0.5 else n <- 1
+      if (force.positive) {
+        n <- 0.5
+      } else {
+        n <- 1
+      }
 
       ## no uncertainty to calculate
       if (!uncertainty) {
@@ -987,7 +1011,9 @@ polarPlot <-
         results
       }
 
-      if (exclude.missing) results <- exclude(results)
+      if (exclude.missing) {
+        results <- exclude(results)
+      }
 
       results
     }
@@ -1023,14 +1049,18 @@ polarPlot <-
     }
 
     ## remove wind speeds > upper to make a circle
-    if (clip) res$z[(res$u^2 + res$v^2)^0.5 > upper] <- NA
+    if (clip) {
+      res$z[(res$u^2 + res$v^2)^0.5 > upper] <- NA
+    }
 
     ## proper names of labelling
     strip.dat <- strip.fun(res, type, auto.text)
     strip <- strip.dat[[1]]
     strip.left <- strip.dat[[2]]
     pol.name <- strip.dat[[3]]
-    if (uncertainty) strip <- TRUE
+    if (uncertainty) {
+      strip <- TRUE
+    }
 
     ## normalise by divining by mean conditioning value if needed
     if (normalise) {
@@ -1048,7 +1078,9 @@ polarPlot <-
       # make sure smoothing does not results in r>1 or <-1
       # sometimes happens with little data at edges
       id <- which(res$z > 1)
-      if (length(id) > 0) res$z[id] <- 1
+      if (length(id) > 0) {
+        res$z[id] <- 1
+      }
 
       id <- which(res$z < -1)
       if (length(id) > 0) res$z[id] <- -1
@@ -1060,17 +1092,25 @@ polarPlot <-
     }
 
     # Labels for correlation and regression, keep lower case like other labels
-    if (statistic %in% c("r", "Pearson"))
+    if (statistic %in% c("r", "Pearson")) {
       key.header <- expression(italic("Pearson\ncorrelation"))
+    }
 
-    if (statistic == "Spearman")
+    if (statistic == "Spearman") {
       key.header <- expression(italic("Spearman\ncorrelation"))
+    }
 
-    if (statistic == "robust_slope") key.header <- "robust\nslope"
+    if (statistic == "robust_slope") {
+      key.header <- "robust\nslope"
+    }
 
-    if (statistic == "robust_intercept") key.header <- "robust\nintercept"
+    if (statistic == "robust_intercept") {
+      key.header <- "robust\nintercept"
+    }
 
-    if (statistic == "york_slope") key.header <- "York regression\nslope"
+    if (statistic == "york_slope") {
+      key.header <- "York regression\nslope"
+    }
 
     if (statistic == "quantile_slope") {
       key.header <- paste0("quantile slope\n(tau: ", tau, ")")
@@ -1124,7 +1164,9 @@ polarPlot <-
     col.scale <- breaks
 
     ## special handling of layout for uncertainty
-    if (uncertainty & is.null(extra.args$layout)) extra.args$layout <- c(3, 1)
+    if (uncertainty & is.null(extra.args$layout)) {
+      extra.args$layout <- c(3, 1)
+    }
 
     legend <- list(
       col = col,
@@ -1444,7 +1486,9 @@ calculate_weighted_statistics <-
     # openair::scatterPlot(mydata, x = "ws", y = "wd", z = "weight", method = "level")
 
     if (statistic %in% c("r", "Pearson", "Spearman")) {
-      if (statistic == "r") statistic <- "Pearson"
+      if (statistic == "r") {
+        statistic <- "Pearson"
+      }
 
       # Weighted Pearson correlation
       stat_weighted <- contCorr(
@@ -1469,8 +1513,12 @@ calculate_weighted_statistics <-
       )
 
       # Extract statistics
-      if (statistic == "slope") stat_weighted <- fit$coefficients[2]
-      if (statistic == "intercept") stat_weighted <- fit$coefficients[1]
+      if (statistic == "slope") {
+        stat_weighted <- fit$coefficients[2]
+      }
+      if (statistic == "intercept") {
+        stat_weighted <- fit$coefficients[1]
+      }
 
       # Bind together
       result <- data.frame(ws1, wd1, stat_weighted)
@@ -1522,11 +1570,16 @@ calculate_weighted_statistics <-
       # Extract statistics
       if (!inherits(fit, "try-error")) {
         # Extract statistics
-        if (statistic == "robust_slope") stat_weighted <- fit$coefficients[2]
-        if (statistic == "robust_intercept")
+        if (statistic == "robust_slope") {
+          stat_weighted <- fit$coefficients[2]
+        }
+        if (statistic == "robust_intercept") {
           stat_weighted <- fit$coefficients[1]
+        }
       } else {
-        if (statistic == "robust_slope") stat_weighted <- NA
+        if (statistic == "robust_slope") {
+          stat_weighted <- NA
+        }
         if (statistic == "robust_intercept") stat_weighted <- NA
       }
 
@@ -1557,11 +1610,16 @@ calculate_weighted_statistics <-
 
       if (!inherits(fit, "try-error")) {
         # Extract statistics
-        if (statistic == "quantile_slope") stat_weighted <- fit$coefficients[2]
-        if (statistic == "quantile_intercept")
+        if (statistic == "quantile_slope") {
+          stat_weighted <- fit$coefficients[2]
+        }
+        if (statistic == "quantile_intercept") {
           stat_weighted <- fit$coefficients[1]
+        }
       } else {
-        if (statistic == "quantile_slope") stat_weighted <- NA
+        if (statistic == "quantile_slope") {
+          stat_weighted <- NA
+        }
         if (statistic == "quantile_intercept") stat_weighted <- NA
       }
 

--- a/R/windRose.R
+++ b/R/windRose.R
@@ -89,7 +89,9 @@ pollutionRose <- function(
     if (missing(breaks)) breaks <- NA
   }
 
-  if (is.null(breaks)) breaks <- 6
+  if (is.null(breaks)) {
+    breaks <- 6
+  }
 
   if (is.numeric(breaks) & length(breaks) == 1) {
     ## breaks from the minimum to 90th percentile, which generally gives sensible
@@ -341,7 +343,9 @@ windRose <- function(
   plot = TRUE,
   ...
 ) {
-  if (is.null(seg)) seg <- 0.9
+  if (is.null(seg)) {
+    seg <- 0.9
+  }
 
   ## greyscale handling
   if (length(cols) == 1 && cols == "greyscale") {
@@ -484,15 +488,21 @@ windRose <- function(
 
     ## fix negative wd
     id <- which(mydata$wd < 0)
-    if (length(id) > 0) mydata$wd[id] <- mydata$wd[id] + 360
+    if (length(id) > 0) {
+      mydata$wd[id] <- mydata$wd[id] + 360
+    }
 
     pollutant <- "ws"
     key.footer <- "ws"
     wd <- "wd"
     ws <- "ws"
     vars <- c("ws", "wd")
-    if (missing(angle)) angle <- 10
-    if (missing(offset)) offset <- 20
+    if (missing(angle)) {
+      angle <- 10
+    }
+    if (missing(offset)) {
+      offset <- 20
+    }
     ## set the breaks to cover all the data
     if (is.na(breaks[1])) {
       max.br <- max(ceiling(abs(c(
@@ -502,13 +512,19 @@ windRose <- function(
       breaks <- c(-1 * max.br, 0, max.br)
     }
 
-    if (missing(cols)) cols <- c("lightskyblue", "tomato")
+    if (missing(cols)) {
+      cols <- c("lightskyblue", "tomato")
+    }
     seg <- 1
   }
 
-  if (any(type %in% dateTypes)) vars <- c(vars, "date")
+  if (any(type %in% dateTypes)) {
+    vars <- c(vars, "date")
+  }
 
-  if (!is.null(pollutant)) vars <- c(vars, pollutant)
+  if (!is.null(pollutant)) {
+    vars <- c(vars, pollutant)
+  }
 
   mydata <- cutData(mydata, type, ...)
 
@@ -531,7 +547,9 @@ windRose <- function(
     mydata <- mydata[-id, ]
   }
 
-  if (is.null(pollutant)) pollutant <- ws
+  if (is.null(pollutant)) {
+    pollutant <- ws
+  }
 
   mydata$x <- mydata[[pollutant]]
 
@@ -548,7 +566,9 @@ windRose <- function(
   mydata[[wd]][mydata[, ws] < calm.thresh] <- -999 ## set wd to flag where there are calms
   ## do after rounding or -999 changes
 
-  if (length(breaks) == 1) breaks <- 0:(breaks - 1) * ws.int
+  if (length(breaks) == 1) {
+    breaks <- 0:(breaks - 1) * ws.int
+  }
 
   if (max(breaks) < max(mydata$x, na.rm = TRUE)) {
     breaks <- c(breaks, max(mydata$x, na.rm = TRUE))
@@ -629,7 +649,9 @@ windRose <- function(
       if (all(is.na(mean.wd))) {
         mean.wd <- NA
       } else {
-        if (mean.wd < 0) mean.wd <- mean.wd + 360
+        if (mean.wd < 0) {
+          mean.wd <- mean.wd + 360
+        }
         ## show as a negative (bias)
         if (mean.wd > 180) mean.wd <- mean.wd - 360
       }
@@ -709,7 +731,9 @@ windRose <- function(
     wds <- seq(10, 360, 10)
     tmp <- angle * ceiling(wds / angle - 0.5)
     id <- which(tmp == 0)
-    if (length(id > 0)) tmp[id] <- 360
+    if (length(id > 0)) {
+      tmp[id] <- 360
+    }
     tmp <- table(tmp) ## number of sectors spanned
     vars <- grep("Interval[1-9]", names(results)) ## the frequencies, without any calms
 
@@ -838,11 +862,17 @@ windRose <- function(
 
   myby <- if (is.null(grid.value)) pretty(c(0, mymax), 4)[2] else grid.value
 
-  if (myby / mymax > 0.9) myby <- mymax * 0.9
+  if (myby / mymax > 0.9) {
+    myby <- mymax * 0.9
+  }
 
   is_annotated <- any(annotate == TRUE) | any(is.character(annotate))
 
-  if (is_annotated) sub <- stat.lab else sub <- NULL
+  if (is_annotated) {
+    sub <- stat.lab
+  } else {
+    sub <- NULL
+  }
 
   xy.args <- list(
     x = myform,

--- a/man/percentileRose.Rd
+++ b/man/percentileRose.Rd
@@ -7,6 +7,7 @@
 percentileRose(
   mydata,
   pollutant = "nox",
+  ws = "ws",
   wd = "wd",
   type = "default",
   percentile = c(25, 50, 75, 90, 95),
@@ -39,6 +40,8 @@ to plot --- \code{pollutant}.}
 data frame should be supplied e.g. \code{pollutant = "nox"}. More than one
 pollutant can be supplied e.g. \code{pollutant = c("no2", "o3")} provided
 there is only one \code{type}.}
+
+\item{ws}{Name of the column representing wind speed.}
 
 \item{wd}{Name of wind direction field.}
 

--- a/man/polarAnnulus.Rd
+++ b/man/polarAnnulus.Rd
@@ -7,6 +7,7 @@
 polarAnnulus(
   mydata,
   pollutant = "nox",
+  wd = "wd",
   resolution = "fine",
   local.tz = NULL,
   period = "hour",
@@ -43,6 +44,8 @@ evaluation where two species would be expected to have similar
 concentrations. This saves the user stacking the data and it is possible to
 work with columns of data directly. A typical use would be \code{pollutant = c("obs", "mod")} to compare two columns \dQuote{obs} (the observations)
 and \dQuote{mod} (modelled values).}
+
+\item{wd}{Name of wind direction field.}
 
 \item{resolution}{Two plot resolutions can be set: \dQuote{normal} and
 \dQuote{fine} (the default).}

--- a/man/polarDiff.Rd
+++ b/man/polarDiff.Rd
@@ -8,8 +8,9 @@ polarDiff(
   before,
   after,
   pollutant = "nox",
-  type = "default",
   x = "ws",
+  wd = "wd",
+  type = "default",
   limits = NULL,
   auto.text = TRUE,
   plot = TRUE,
@@ -30,6 +31,11 @@ and \dQuote{mod} (modelled values). When pair-wise statistics such as
 Pearson correlation and regression techniques are to be plotted,
 \code{pollutant} takes two elements too. For example, \code{pollutant = c("bc", "pm25")} where \code{"bc"} is a function of \code{"pm25"}.}
 
+\item{x}{Name of variable to plot against wind direction in polar
+coordinates, the default is wind speed, \dQuote{ws}.}
+
+\item{wd}{Name of wind direction field.}
+
 \item{type}{\code{type} determines how the data are split i.e. conditioned,
 and then plotted. The default is will produce a single plot using the
 entire data. Type can be one of the built-in types as detailed in
@@ -48,9 +54,6 @@ Type can be up length two e.g. \code{type = c("season", "weekday")} will
 produce a 2x2 plot split by season and day of the week. Note, when two
 types are provided the first forms the columns and the second the rows.}
 
-\item{x}{Name of variable to plot against wind direction in polar
-coordinates, the default is wind speed, \dQuote{ws}.}
-
 \item{limits}{The function does its best to choose sensible limits
 automatically. However, there are circumstances when the user will wish to
 set different ones. An example would be a series of plots showing each year
@@ -67,7 +70,6 @@ analysing data to extract plot components and plotting them in other ways.}
 \item{...}{
   Arguments passed on to \code{\link[=polarPlot]{polarPlot}}
   \describe{
-    \item{\code{wd}}{Name of wind direction field.}
     \item{\code{statistic}}{The statistic that should be applied to each wind
 speed/direction bin. Because of the smoothing involved, the colour scale
 for some of these statistics is only to provide an indication of overall

--- a/man/polarFreq.Rd
+++ b/man/polarFreq.Rd
@@ -7,6 +7,8 @@
 polarFreq(
   mydata,
   pollutant = NULL,
+  ws = "ws",
+  wd = "wd",
   statistic = "frequency",
   ws.int = 1,
   wd.nint = 36,
@@ -35,6 +37,10 @@ polarFreq(
 
 \item{pollutant}{Mandatory. A pollutant name corresponding to a variable in
 a data frame should be supplied e.g. \code{pollutant = "nox"}}
+
+\item{ws}{Name of the column representing wind speed.}
+
+\item{wd}{Name of wind direction field.}
 
 \item{statistic}{The statistic that should be applied to each wind
 speed/direction bin. Can be \dQuote{frequency}, \dQuote{mean},


### PR DESCRIPTION
This PR adds the following arguments to the following functions:

- `wd` to `polarDiff()`
- `ws` and `wd` to `polarFreq()`
- `ws` to `percentileRose()`
- `wd` to `polarAnnulus()`

This brings them in line with `windRose()` and `polarPlot()`, which already have these arguments (or their equivalents).

If this is merged these changes can be propagated to `{openairmaps}` also, which currently hard-codes "ws" & "wd".

There may be other functions that could use a `ws` / `wd` arg (e.g., ones with `windflow` options); I will review. 