### PR TITLE
Refine `calendarPlot()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,9 @@
 
 - `calendarPlot()` refinements:
 
-    - `calendarPlot()` has gained the `percentile` argument, passed on to `timeAverage()`.
+    - Gained the `percentile` argument, passed on to `timeAverage()`.
+    
+    - Gained the `show.year` argument, defaulting to `TRUE`. When `FALSE` and only one year of data is given, the strip titles will only read, e.g., "January" instead of "January-2000". This can create cleaner plots, as well as being useful for certain edge cases (e.g., if the calendarPlot is showing day-of-year averages over multiple years).
     
     - When `statistic == "min"` and `annotation %in% c("ws", "wd")`, the ws/wd returned will correspond to the minimum daily pollutant, rather than the minimum daily ws/wd.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,12 @@
 
 - `timePlot()` has gained the `x.relation` argument, allowing for different x ranges on different panels.
 
+- `calendarPlot()` refinements:
+
+    - `calendarPlot()` has gained the `percentile` argument, passed on to `timeAverage()`.
+    
+    - When `statistic == "min"` and `annotation %in% c("ws", "wd")`, the ws/wd returned will correspond to the minimum daily pollutant, rather than the minimum daily ws/wd.
+
 ## Bug Fixes
 
 - `importUKAQ()` now closes its `url()` connections and generally fails more gracefully when `data_type %in% c("annual", "monthly", "daqi")`. This was already the case for other data types.

--- a/R/calendarPlot.R
+++ b/R/calendarPlot.R
@@ -322,7 +322,10 @@ calendarPlot <-
         dplyr::add_count(.data$cuts, name = "month_counts")
 
       # if any duplicates, set show.year = TRUE
-      if (any(verify_duplicates$month_counts > 1L)) {
+      if (
+        any(verify_duplicates$month_counts > 1L) ||
+          dplyr::n_distinct(verify_duplicates$years) > 1L
+      ) {
         mydata <- dplyr::mutate(
           mydata,
           cuts = format(.data$date, "%B-%Y"),

--- a/R/calendarPlot.R
+++ b/R/calendarPlot.R
@@ -405,26 +405,15 @@ calendarPlot <-
     strip <- strip.fun(mydata, type, auto.text)[[1]]
 
     # handle breaks
+    category <- FALSE
     if (!anyNA(breaks)) {
       # assign labels if no labels are given
-      if (anyNA(labels)) {
-        labels <- c()
-        for (i in seq_along(breaks)) {
-          lhs <- breaks[i]
-          rhs <- breaks[i + 1]
-          str <- paste(lhs, rhs, sep = " - ")
-          labels <- append(labels, str)
-        }
-        labels <- labels[-i]
-      }
-
+      labels <- breaksToLabels(breaks, labels)
       category <- TRUE
       mydata <- dplyr::mutate(
         mydata,
         conc.mat = cut(.data$conc.mat, breaks = breaks, labels = labels)
       )
-    } else {
-      category <- FALSE
     }
 
     ## ---- Categorical Scales ----

--- a/R/calendarPlot.R
+++ b/R/calendarPlot.R
@@ -31,9 +31,8 @@
 #' passed to [calendarPlot()] and `statistic = "max"` chosen, which will plot
 #' maximum daily 8-hour mean concentrations.
 #'
-#' @param mydata A data frame minimally containing `date` and at least one other
-#'   numeric variable. The date should be in either `Date` format or class
-#'   `POSIXct`.
+#' @inheritParams timePlot
+#'
 #' @param pollutant Mandatory. A pollutant name corresponding to a variable in a
 #'   data frame should be supplied e.g. `pollutant = "nox". `
 #' @param year Year to plot e.g. `year = 2003`. If not supplied all data
@@ -44,16 +43,15 @@
 #'   12)` to only plot January and December.
 #' @param type Not yet implemented.
 #' @param annotate This option controls what appears on each day of the
-#'   calendar. Can be: "date" --- shows day of the month; "wd"
-#'   --- shows vector-averaged wind direction, or "ws" --- shows
-#'   vector-averaged wind direction scaled by wind speed. Finally it can be
-#'   \dQuote{value} which shows the daily mean value.
+#'   calendar. Can be:
+#'   - `"date"` --- shows day of the month
+#'   - `"wd"` --- shows vector-averaged wind direction
+#'   - `"ws"` --- shows vector-averaged wind direction scaled by wind speed
+#'   - `"value"` --- shows the daily mean value
 #' @param statistic Statistic passed to [timeAverage()]. Note that if `statistic
 #'   = "max"` and `annotate` is "ws" or "wd", the hour corresponding to the
 #'   maximum concentration of `polluant` is used to provide the associated `ws`
 #'   or `wd` and not the maximum daily `ws` or `wd`.
-#' @param cols Colours to be used for plotting. See [openColours()] for more
-#'   details.
 #' @param limits Use this option to manually set the colour scale limits. This
 #'   is useful in the case when there is a need for two or more plots and a
 #'   consistent scale is needed on each. Set the limits to cover the maximum
@@ -83,7 +81,7 @@
 #'   available in a day for the value to be calculate, else the data is removed.
 #' @param breaks If a categorical scale is required then these breaks will be
 #'   used. For example, `breaks = c(0, 50, 100, 1000)`. In this case
-#'   \dQuote{good} corresponds to values between 0 and 50 and so on. Users
+#'   "good" corresponds to values between 0 and 50 and so on. Users
 #'   should set the maximum value of `breaks` to exceed the maximum data value
 #'   to ensure it is within the maximum final range e.g. 100--1000 in this case.
 #' @param labels If a categorical scale is defined using `breaks`, then `labels`
@@ -109,11 +107,6 @@
 #'   arguments currently include `"top"`, `"right"`, `"bottom"` and `"left"`.
 #' @param key Fine control of the scale key via [drawOpenKey()]. See
 #'   [drawOpenKey()] for further details.
-#' @param auto.text Either `TRUE` (default) or `FALSE`. If `TRUE` titles and
-#'   axis labels will automatically try and format pollutant names and units
-#'   properly e.g.  by subscripting the `2' in NO2.
-#' @param plot Should a plot be produced? `FALSE` can be useful when analysing
-#'   data to extract calendar plot components and plotting them in other ways.
 #' @param ... Other graphical parameters are passed onto the `lattice` function
 #'   [lattice::levelplot()], with common axis and title labelling options (such
 #'   as `xlab`, `ylab`, `main`) being passed to via [quickText()] to handle

--- a/R/timePlot.R
+++ b/R/timePlot.R
@@ -294,6 +294,7 @@ timePlot <- function(
     mydata = mydata,
     pollutant = pollutant,
     type = type,
+    avg.time = avg.time,
     date.pad = date.pad,
     windflow = windflow,
     ...
@@ -711,6 +712,7 @@ prepare_timeplot_data <- function(
   mydata,
   pollutant,
   type,
+  avg.time,
   date.pad,
   windflow,
   ...
@@ -733,7 +735,9 @@ prepare_timeplot_data <- function(
   mydata <- cutData(mydata, type, ...)
 
   # check for duplicates - can't really have duplicate data in a timeplot
-  checkDuplicateRows(mydata, type, fn = cli::cli_abort)
+  if (avg.time == "default") {
+    checkDuplicateRows(mydata, type, fn = cli::cli_abort)
+  }
 
   # return data
   return(mydata)

--- a/R/trendLevel.R
+++ b/R/trendLevel.R
@@ -235,17 +235,7 @@ trendLevel <- function(
   # assume pollutant scale is not a categorical value
   category <- FALSE
   if (!anyNA(breaks)) {
-    # assign labels if no labels are given
-    if (anyNA(labels)) {
-      labels <- c()
-      for (i in seq_along(breaks)) {
-        lhs <- breaks[i]
-        rhs <- breaks[i + 1]
-        str <- paste(lhs, rhs, sep = " - ")
-        labels <- append(labels, str)
-      }
-      labels <- labels[-i]
-    }
+    labels <- breaksToLabels(breaks, labels)
     category <- TRUE
   }
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -765,9 +765,9 @@ checkDuplicateRows <- function(mydata, type = NULL, fn = cli::cli_warn) {
     flag <-
       split(mydata, mydata[type], drop = TRUE) |>
       purrr::map_vec(function(x) {
-          dates <- x$date
-          unique_dates <- unique(x$date)
-          length(dates) != length(unique_dates)
+        dates <- x$date
+        unique_dates <- unique(x$date)
+        length(dates) != length(unique_dates)
       }) |>
       any()
   }
@@ -826,4 +826,20 @@ mapType <- function(
   ) |>
     dplyr::bind_rows() |>
     dplyr::relocate(dplyr::any_of(type))
+}
+
+#' Create nice labels out of breaks, if only breaks are provided
+#' @noRd
+breaksToLabels <- function(breaks, labels = NA) {
+  if (any(is.na(labels)) || is.null(labels)) {
+    labels <- c()
+    for (i in seq_along(breaks)) {
+      lhs <- breaks[i]
+      rhs <- breaks[i + 1]
+      str <- paste(lhs, rhs, sep = " - ")
+      labels <- append(labels, str)
+    }
+    labels <- labels[-i]
+  }
+  return(labels)
 }

--- a/man/calendarPlot.Rd
+++ b/man/calendarPlot.Rd
@@ -27,6 +27,7 @@ calendarPlot(
   w.shift = 0,
   w.abbr.len = 1,
   remove.empty = TRUE,
+  show.year = TRUE,
   key.header = "",
   key.footer = "",
   key.position = "right",
@@ -61,7 +62,8 @@ calendar. Can be:
 
 \item{statistic}{Statistic passed to \code{\link[=timeAverage]{timeAverage()}}. Note that if \code{statistic \%in\% c("max", "min")} and \code{annotate} is "ws" or "wd", the hour
 corresponding to the maximum/minimum concentration of \code{polluant} is used to
-provide the associated \code{ws} or \code{wd} and not the maximum/minimum daily \code{ws} or \code{wd}.}
+provide the associated \code{ws} or \code{wd} and not the maximum/minimum daily \code{ws}
+or \code{wd}.}
 
 \item{data.thresh}{The data capture threshold to use (\%). A value of zero
 means that all available data will be used in a particular period
@@ -127,6 +129,11 @@ abbreviate "Monday" to "Mon".}
 
 \item{remove.empty}{Should months with no data present be removed? Default is
 \code{TRUE}.}
+
+\item{show.year}{If only a single year is being plotted, should the calendar
+labels include the year label? \code{TRUE} creates labels like "January-2000",
+\code{FALSE} labels just as "January". If multiple years of data are detected,
+this option is forced to be \code{TRUE}.}
 
 \item{key.header}{Adds additional text/labels to the scale key. For example,
 passing \code{calendarPlot(mydata, key.header = "header", key.footer = "footer")} adds addition text above and below the scale key. These

--- a/man/calendarPlot.Rd
+++ b/man/calendarPlot.Rd
@@ -7,11 +7,12 @@
 calendarPlot(
   mydata,
   pollutant = "nox",
-  year = 2003,
-  month = 1:12,
-  type = "default",
+  year = NULL,
+  month = NULL,
   annotate = "date",
   statistic = "mean",
+  data.thresh = 0,
+  percentile = NA,
   cols = "heat",
   limits = c(0, 100),
   lim = NULL,
@@ -21,13 +22,11 @@ calendarPlot(
   cex.lim = c(0.6, 1),
   cex.date = 0.6,
   digits = 0,
-  data.thresh = 0,
   labels = NA,
   breaks = NA,
   w.shift = 0,
   w.abbr.len = 1,
   remove.empty = TRUE,
-  main = NULL,
   key.header = "",
   key.footer = "",
   key.position = "right",
@@ -51,8 +50,6 @@ potentially spanning several years will be plotted.}
 plot an entire year even if months are missing. To only plot certain months
 use the \code{month} option where month is a numeric 1:12 e.g. \code{month = c(1, 12)} to only plot January and December.}
 
-\item{type}{Not yet implemented.}
-
 \item{annotate}{This option controls what appears on each day of the
 calendar. Can be:
 \itemize{
@@ -62,9 +59,19 @@ calendar. Can be:
 \item \code{"value"} --- shows the daily mean value
 }}
 
-\item{statistic}{Statistic passed to \code{\link[=timeAverage]{timeAverage()}}. Note that if \code{statistic = "max"} and \code{annotate} is "ws" or "wd", the hour corresponding to the
-maximum concentration of \code{polluant} is used to provide the associated \code{ws}
-or \code{wd} and not the maximum daily \code{ws} or \code{wd}.}
+\item{statistic}{Statistic passed to \code{\link[=timeAverage]{timeAverage()}}. Note that if \code{statistic \%in\% c("max", "min")} and \code{annotate} is "ws" or "wd", the hour
+corresponding to the maximum/minimum concentration of \code{polluant} is used to
+provide the associated \code{ws} or \code{wd} and not the maximum/minimum daily \code{ws} or \code{wd}.}
+
+\item{data.thresh}{The data capture threshold to use (\%). A value of zero
+means that all available data will be used in a particular period
+regardless if of the number of values available. Conversely, a value of 100
+will mean that all data will need to be present for the average to be
+calculated, else it is recorded as \code{NA}. See also \code{interval}, \code{start.date}
+and \code{end.date} to see whether it is advisable to set these other options.}
+
+\item{percentile}{The percentile level in percent used when \code{statistic = "percentile"} and when aggregating the data with \code{avg.time}. More than one
+percentile level is allowed for \code{type = "default"} e.g. \code{percentile = c(50, 95)}. Not used if \code{avg.time = "default"}.}
 
 \item{cols}{Colours to be used for plotting; see \code{\link[=openColours]{openColours()}} for details.}
 
@@ -100,18 +107,14 @@ the text above \code{lim}.}
 \item{digits}{The number of digits used to display concentration values when
 \code{annotate = "value"}.}
 
-\item{data.thresh}{Data capture threshold passed to \code{\link[=timeAverage]{timeAverage()}}. For
-example, \code{data.thresh = 75} means that at least 75\\% of the data must be
-available in a day for the value to be calculate, else the data is removed.}
-
 \item{labels}{If a categorical scale is defined using \code{breaks}, then \code{labels}
 can be used to override the default category labels, e.g., \code{labels = c("good", "bad", "very bad")}. Note there is one less label than break.}
 
 \item{breaks}{If a categorical scale is required then these breaks will be
-used. For example, \code{breaks = c(0, 50, 100, 1000)}. In this case
-\dQuote{good} corresponds to values between 0 and 50 and so on. Users
-should set the maximum value of \code{breaks} to exceed the maximum data value
-to ensure it is within the maximum final range e.g. 100--1000 in this case.}
+used. For example, \code{breaks = c(0, 50, 100, 1000)}. In this case "good"
+corresponds to values between 0 and 50 and so on. Users should set the
+maximum value of \code{breaks} to exceed the maximum data value to ensure it is
+within the maximum final range e.g. 100--1000 in this case.}
 
 \item{w.shift}{Controls the order of the days of the week. By default the
 plot shows Saturday first (\code{w.shift = 0}). To change this so that it starts
@@ -124,8 +127,6 @@ abbreviate "Monday" to "Mon".}
 
 \item{remove.empty}{Should months with no data present be removed? Default is
 \code{TRUE}.}
-
-\item{main}{The plot title; default is pollutant and year.}
 
 \item{key.header}{Adds additional text/labels to the scale key. For example,
 passing \code{calendarPlot(mydata, key.header = "header", key.footer = "footer")} adds addition text above and below the scale key. These

--- a/man/calendarPlot.Rd
+++ b/man/calendarPlot.Rd
@@ -38,9 +38,8 @@ calendarPlot(
 )
 }
 \arguments{
-\item{mydata}{A data frame minimally containing \code{date} and at least one other
-numeric variable. The date should be in either \code{Date} format or class
-\code{POSIXct}.}
+\item{mydata}{A data frame of time series. Must include a \code{date} field and at
+least one variable to plot.}
 
 \item{pollutant}{Mandatory. A pollutant name corresponding to a variable in a
 data frame should be supplied e.g. \verb{pollutant = "nox". }}
@@ -55,17 +54,19 @@ use the \code{month} option where month is a numeric 1:12 e.g. \code{month = c(1
 \item{type}{Not yet implemented.}
 
 \item{annotate}{This option controls what appears on each day of the
-calendar. Can be: "date" --- shows day of the month; "wd"
---- shows vector-averaged wind direction, or "ws" --- shows
-vector-averaged wind direction scaled by wind speed. Finally it can be
-\dQuote{value} which shows the daily mean value.}
+calendar. Can be:
+\itemize{
+\item \code{"date"} --- shows day of the month
+\item \code{"wd"} --- shows vector-averaged wind direction
+\item \code{"ws"} --- shows vector-averaged wind direction scaled by wind speed
+\item \code{"value"} --- shows the daily mean value
+}}
 
 \item{statistic}{Statistic passed to \code{\link[=timeAverage]{timeAverage()}}. Note that if \code{statistic = "max"} and \code{annotate} is "ws" or "wd", the hour corresponding to the
 maximum concentration of \code{polluant} is used to provide the associated \code{ws}
 or \code{wd} and not the maximum daily \code{ws} or \code{wd}.}
 
-\item{cols}{Colours to be used for plotting. See \code{\link[=openColours]{openColours()}} for more
-details.}
+\item{cols}{Colours to be used for plotting; see \code{\link[=openColours]{openColours()}} for details.}
 
 \item{limits}{Use this option to manually set the colour scale limits. This
 is useful in the case when there is a need for two or more plots and a
@@ -141,10 +142,10 @@ arguments currently include \code{"top"}, \code{"right"}, \code{"bottom"} and \c
 
 \item{auto.text}{Either \code{TRUE} (default) or \code{FALSE}. If \code{TRUE} titles and
 axis labels will automatically try and format pollutant names and units
-properly e.g.  by subscripting the `2' in NO2.}
+properly, e.g., by subscripting the '2' in NO2.}
 
 \item{plot}{Should a plot be produced? \code{FALSE} can be useful when analysing
-data to extract calendar plot components and plotting them in other ways.}
+data to extract plot components and plotting them in other ways.}
 
 \item{...}{Other graphical parameters are passed onto the \code{lattice} function
 \code{\link[lattice:levelplot]{lattice::levelplot()}}, with common axis and title labelling options (such


### PR DESCRIPTION
Fixes #435 and #150. Refactor, plus:

- Adds `percentile` for use w/ `statistic = "percentile"`

- Makes `statistic = "min"` & `annotate = "ws"` work similarly to `statistic = "max"`.

- Adds `show.year` which, if only one year of data is given, simplifies the strip text to just show the month rather than e.g. "January-2000". If multiple years are given, this is ignored. Fixes #150.

That last one is nice, I think. The specific use case in that issue is for averaging over multiple years so there is no "year" to plot (maybe we can add that as an argument?), but it's also handy just to clean up the labels a bit.