### PR TITLE
Fix `timePlot()` `windflow` when ws/wd are in `pollutant`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 - `importUKAQ()` now closes its `url()` connections and generally fails more gracefully when `data_type %in% c("annual", "monthly", "daqi")`. This was already the case for other data types.
 
+- The `windflow` argument of `timePlot()` now works when `"ws"` and/or `"wd"` are in `pollutant`.
+
 # openair 2.19.0
 
 ## Deprecations

--- a/R/quickText.R
+++ b/R/quickText.R
@@ -56,13 +56,10 @@ quickText <- function(text, auto.text = TRUE) {
   ans <- gsub("co ", "' 'CO ' '", ans)
   ans <- gsub("co,", "' 'CO,' '", ans)
   ans <- gsub("nmhc", "' 'NMHC' '", ans)
-
-  ans <- if (nchar(as.character(text)) == 2 && length(grep("ws", text)) > 0) {
-    gsub("ws", "' 'wind spd.' '", ans)
-  } else {
-    ans
-  }
-  ans <- gsub("wd", "' 'wind dir.' '", ans)
+  ans <- gsub("\\bws\\b", "' 'wind spd.' '", ans)
+  ans <- gsub("\\bwd\\b", "' 'wind dir.' '", ans)
+  ans <- gsub("\\bWS\\b", "' 'wind spd.' '", ans)
+  ans <- gsub("\\bWD\\b", "' 'wind dir.' '", ans)
   ans <- gsub("rh ", "' 'relative humidity' '", ans)
   ans <- gsub("PM10", "' 'PM' [10] * '", ans)
   ans <- gsub("pm10", "' 'PM' [10] * '", ans)

--- a/R/timePlot.R
+++ b/R/timePlot.R
@@ -308,7 +308,8 @@ timePlot <- function(
     statistic = statistic,
     avg.time = avg.time,
     data.thresh = data.thresh,
-    percentile = percentile
+    percentile = percentile,
+    windflow = windflow
   )
   pollutant <- mydata$pollutant
   mydata <- mydata$data
@@ -752,7 +753,8 @@ time_average_timeplot_data <- function(
   statistic,
   avg.time,
   data.thresh,
-  percentile
+  percentile,
+  windflow
 ) {
   # average the data if necessary (default does nothing)
   if (avg.time != "default") {
@@ -791,6 +793,18 @@ time_average_timeplot_data <- function(
     mydata$default <- "default"
   }
 
+  # need to flag if ws/wd are being plotted *and* used for windflow
+  flag_wind_pollutant <- !is.null(windflow) &&
+    ("ws" %in% pollutant || "wd" %in% pollutant)
+
+  # retain ws/wd if needed later
+  if (flag_wind_pollutant) {
+    # only select what is being pivoted, as it will need joining back on
+    met_vars <- c("ws", "wd")
+    met_vars <- met_vars[met_vars %in% pollutant]
+    met_data <- dplyr::select(mydata, dplyr::any_of(c("date", met_vars)))
+  }
+
   # reshape
   mydata <-
     tidyr::pivot_longer(
@@ -799,6 +813,16 @@ time_average_timeplot_data <- function(
       names_to = "variable",
       values_to = "value"
     )
+
+  # bind on ws/wd if needed for windflow
+  if (flag_wind_pollutant) {
+    mydata <- dplyr::left_join(
+      mydata,
+      met_data,
+      by = dplyr::join_by("date")
+    ) %>%
+      dplyr::relocate(dplyr::any_of(c("ws", "wd")), .after = "date")
+  }
 
   # need to return pollutant as it can change
   return(list(


### PR DESCRIPTION
Fixes #212.

Previously, `timePlot()` would pivot away the ws/wd columns if they were also in "pollutant".

This PR restores them to `mydata` if the user also wants to use `windflow`.

Can now create plots of wind speed with wind direction on them:

<img width="672" height="480" alt="image" src="https://github.com/user-attachments/assets/6686dad9-3ad3-4d04-921e-03cbc8cffa68" />
