### PR TITLE
Add `grid.nx` and `grid.ny` to `trajPlot()` and `trajLevel()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -63,4 +63,4 @@ Language: en-GB
 LazyData: yes
 LazyLoad: yes
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 - `timePlot()` has gained the `x.relation` argument, allowing for different x ranges on different panels.
 
+- `trajPlot()` and `trajLevel()` have gained the `grid.nx` and `grid.ny` arguments which can be used to control the number of ticks on the coordinate grid, or remove it altogether.
+
 ## Bug Fixes
 
 - `timePlot()` now allows duplicate dates when `time.avg` is used. The user will still recieve a warning from `timeAverage()`, which is used internally, but the plot will still be created.

--- a/R/scatterPlot.R
+++ b/R/scatterPlot.R
@@ -453,6 +453,9 @@ scatterPlot <- function(
 
   Args$grid.col <- Args$grid.col %||% "deepskyblue"
 
+  Args$grid.nx <- Args$grid.nx %||% 9
+  Args$grid.ny <- Args$grid.ny %||% 9
+
   Args$npoints <- Args$npoints %||% 12
 
   Args$origin <- Args$origin %||% TRUE
@@ -1872,13 +1875,17 @@ add.map <- function(Args, ...) {
     )
   }
 
-  map.grid2(
-    lim = Args$trajLims,
-    projection = Args$projection,
-    parameters = Args$parameters,
-    orientation = Args$orientation,
-    col = Args$grid.col
-  )
+  if (Args$grid.nx != 0 || Args$grid.ny != 0) {
+    map.grid2(
+      lim = Args$trajLims,
+      projection = Args$projection,
+      parameters = Args$parameters,
+      orientation = Args$orientation,
+      col = Args$grid.col,
+      nx = Args$grid.nx,
+      ny = Args$grid.ny
+    )
+  }
 }
 
 

--- a/R/trajLevel.R
+++ b/R/trajLevel.R
@@ -182,6 +182,8 @@ trajLevel <- function(
   parameters = c(51, 51),
   orientation = c(90, 0, 0),
   grid.col = "deepskyblue",
+  grid.nx = 9,
+  grid.ny = grid.nx,
   origin = TRUE,
   plot = TRUE,
   ...
@@ -596,6 +598,8 @@ trajLevel <- function(
     parameters = parameters,
     orientation = orientation,
     grid.col = grid.col,
+    grid.nx = grid.nx,
+    grid.ny = grid.ny,
     trajLims = trajLims,
     receptor = receptor,
     origin = origin,

--- a/R/trajPlot.R
+++ b/R/trajPlot.R
@@ -85,6 +85,10 @@
 #'   coordinates in the map.
 #' @param grid.col The colour of the map grid to be used. To remove the grid set
 #'   `grid.col = "transparent"`.
+#' @param grid.nx,grid.ny The approximate number of ticks to draw on the map
+#'   grid. `grid.nx` defaults to `9`, and `grid.ny` defaults to whatever value
+#'   is passed to `grid.nx`. Setting both values to `0` will remove the grid
+#'   entirely.
 #' @param npoints A dot is placed every `npoints` along each full trajectory.
 #'   For hourly back trajectories points are plotted every `npoint` hours. This
 #'   helps to understand where the air masses were at particular times and get a
@@ -152,6 +156,8 @@ trajPlot <- function(
   parameters = c(51, 51),
   orientation = c(90, 0, 0),
   grid.col = "deepskyblue",
+  grid.nx = 9,
+  grid.ny = grid.nx,
   npoints = 12,
   origin = TRUE,
   plot = TRUE,
@@ -300,6 +306,8 @@ trajPlot <- function(
       parameters = parameters,
       orientation = orientation,
       grid.col = grid.col,
+      grid.nx = grid.nx,
+      grid.ny = grid.ny,
       trajLims = trajLims,
       receptor = receptor,
       npoints = npoints,
@@ -328,6 +336,8 @@ trajPlot <- function(
       parameters = parameters,
       orientation = orientation,
       grid.col = grid.col,
+      grid.nx = grid.nx,
+      grid.ny = grid.ny,
       trajLims = trajLims,
       receptor = receptor,
       npoints = npoints,

--- a/R/trajPlot.R
+++ b/R/trajPlot.R
@@ -88,7 +88,8 @@
 #' @param grid.nx,grid.ny The approximate number of ticks to draw on the map
 #'   grid. `grid.nx` defaults to `9`, and `grid.ny` defaults to whatever value
 #'   is passed to `grid.nx`. Setting both values to `0` will remove the grid
-#'   entirely.
+#'   entirely. The number of ticks is approximate as this value is passed to
+#'   [pretty()] to determine nice-looking, round breakpoints.
 #' @param npoints A dot is placed every `npoints` along each full trajectory.
 #'   For hourly back trajectories points are plotted every `npoint` hours. This
 #'   helps to understand where the air masses were at particular times and get a

--- a/man/trajLevel.Rd
+++ b/man/trajLevel.Rd
@@ -170,7 +170,8 @@ coordinates in the map.}
 \item{grid.nx, grid.ny}{The approximate number of ticks to draw on the map
 grid. \code{grid.nx} defaults to \code{9}, and \code{grid.ny} defaults to whatever value
 is passed to \code{grid.nx}. Setting both values to \code{0} will remove the grid
-entirely.}
+entirely. The number of ticks is approximate as this value is passed to
+\code{\link[=pretty]{pretty()}} to determine nice-looking, round breakpoints.}
 
 \item{origin}{If true a filled circle dot is shown to mark the receptor
 point.}

--- a/man/trajLevel.Rd
+++ b/man/trajLevel.Rd
@@ -30,6 +30,8 @@ trajLevel(
   parameters = c(51, 51),
   orientation = c(90, 0, 0),
   grid.col = "deepskyblue",
+  grid.nx = 9,
+  grid.ny = grid.nx,
   origin = TRUE,
   plot = TRUE,
   ...
@@ -164,6 +166,11 @@ coordinates in the map.}
 
 \item{grid.col}{The colour of the map grid to be used. To remove the grid set
 \code{grid.col = "transparent"}.}
+
+\item{grid.nx, grid.ny}{The approximate number of ticks to draw on the map
+grid. \code{grid.nx} defaults to \code{9}, and \code{grid.ny} defaults to whatever value
+is passed to \code{grid.nx}. Setting both values to \code{0} will remove the grid
+entirely.}
 
 \item{origin}{If true a filled circle dot is shown to mark the receptor
 point.}

--- a/man/trajPlot.Rd
+++ b/man/trajPlot.Rd
@@ -23,6 +23,8 @@ trajPlot(
   parameters = c(51, 51),
   orientation = c(90, 0, 0),
   grid.col = "deepskyblue",
+  grid.nx = 9,
+  grid.ny = grid.nx,
   npoints = 12,
   origin = TRUE,
   plot = TRUE,
@@ -112,6 +114,11 @@ coordinates in the map.}
 
 \item{grid.col}{The colour of the map grid to be used. To remove the grid set
 \code{grid.col = "transparent"}.}
+
+\item{grid.nx, grid.ny}{The approximate number of ticks to draw on the map
+grid. \code{grid.nx} defaults to \code{9}, and \code{grid.ny} defaults to whatever value
+is passed to \code{grid.nx}. Setting both values to \code{0} will remove the grid
+entirely.}
 
 \item{npoints}{A dot is placed every \code{npoints} along each full trajectory.
 For hourly back trajectories points are plotted every \code{npoint} hours. This

--- a/man/trajPlot.Rd
+++ b/man/trajPlot.Rd
@@ -118,7 +118,8 @@ coordinates in the map.}
 \item{grid.nx, grid.ny}{The approximate number of ticks to draw on the map
 grid. \code{grid.nx} defaults to \code{9}, and \code{grid.ny} defaults to whatever value
 is passed to \code{grid.nx}. Setting both values to \code{0} will remove the grid
-entirely.}
+entirely. The number of ticks is approximate as this value is passed to
+\code{\link[=pretty]{pretty()}} to determine nice-looking, round breakpoints.}
 
 \item{npoints}{A dot is placed every \code{npoints} along each full trajectory.
 For hourly back trajectories points are plotted every \code{npoint} hours. This


### PR DESCRIPTION
Fixes #24.

Adds `grid.nx` and `grid.ny` to control the number of ticks on the map grid of `trajLevel()` and `trajPlot()`. If both are zero, the grid is omitted entirely.

`grid.ny` inherits from `grid.nx` by default, as I imagine most users will want a roughly square grid.

``` r
devtools::load_all()
#> ℹ Loading openair

trajLevel(openairmaps::traj_data, grid.nx = 20)
```

![](https://i.imgur.com/5OBPqG5.png)<!-- -->

``` r

trajLevel(openairmaps::traj_data, grid.nx = 3)
```

![](https://i.imgur.com/iEYyIxv.png)<!-- -->

``` r

trajLevel(openairmaps::traj_data, grid.nx = 0)
```

![](https://i.imgur.com/VpuQ26N.png)<!-- -->

<sup>Created on 2025-09-28 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
